### PR TITLE
Renamed statement to query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=relations-sql
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.1.0
+VERSION?=0.2.0
 DEBUG_PORT=5678
 TTY=$(shell if tty -s; then echo "-it"; fi)
 VOLUMES=-v ${PWD}/lib:/opt/service/lib \
@@ -37,7 +37,7 @@ setup:
 	python -m relations_sql.criterion && \
 	python -m relations_sql.criteria && \
 	python -m relations_sql.clause && \
-	python -m relations_sql.statement"
+	python -m relations_sql.query"
 
 tag:
 	-git tag -a $(VERSION) -m "Version $(VERSION)"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,115 @@
 # python-relations-sql
+
 Module for interacting with Relations and SQL
+
+This is an abstract library that'll be used to create libraries for pymysql, psycopg2, sqlite3, etc.
+
+But here's some of the main unittests so you get the general idea.
+
+# import
+
+All the classes are capitalized to prevent collisions with reserved keywords. Plus it looks like actual SQL. So you can do a full import without worries.
+
+```python
+from relations_sql import *
+```
+
+# select
+
+```python
+query = SELECT("*").OPTIONS("FAST").FROM("people").WHERE(stuff__gt="things")
+
+query.generate()
+self.assertEqual(query.sql, "SELECT FAST * FROM `people` WHERE `stuff`>%s")
+self.assertEqual(query.args, ["things"])
+
+query = SELECT(
+    "*"
+).FROM(
+    people=SELECT(
+        "a.b.c"
+    ).FROM(
+        "d.e"
+    )
+).WHERE(
+    stuff__in=SELECT(
+        "f"
+    ).FROM(
+        "g"
+    ).WHERE(
+        things__a__0___1____2_____3__gt=5
+    )
+)
+
+query.generate()
+self.assertEqual(query.sql,
+    "SELECT * FROM (SELECT `a`.`b`.`c` FROM `d`.`e`) "
+    "AS `people` WHERE `stuff` IN "
+    "(SELECT `f` FROM `g` WHERE `things`>%s>JSON(%s))"
+)
+self.assertEqual(query.args, ['$."a"[0][-1]."2"."-3"', '5'])
+
+query.GROUP_BY("fee", "fie").HAVING(foe="fum").ORDER_BY("yin", yang=DESC).LIMIT(1, 2)
+
+query.generate()
+self.assertEqual(query.sql,
+    "SELECT * FROM (SELECT `a`.`b`.`c` FROM `d`.`e`) "
+    "AS `people` WHERE `stuff` IN "
+    "(SELECT `f` FROM `g` WHERE `things`>%s>JSON(%s)) "
+    "GROUP BY `fee`,`fie` HAVING `foe`=%s "
+    "ORDER BY `yin`,`yang` DESC LIMIT %s,%s"
+)
+self.assertEqual(query.args, ['$."a"[0][-1]."2"."-3"', '5', 'fum', 1, 2])
+```
+
+# insert
+
+```python
+query = INSERT("people").VALUES(stuff=1, things=2).VALUES(3, 4)
+
+query.generate()
+self.assertEqual(query.sql,"INSERT INTO `people` (`stuff`,`things`) VALUES (%s,%s),(%s,%s)")
+self.assertEqual(query.args, [1, 2, 3, 4])
+
+query = INSERT("people").OPTIONS("FAST")
+query.SELECT("stuff").FROM("things")
+
+query.generate()
+self.assertEqual(query.sql,"INSERT FAST INTO `people` SELECT `stuff` FROM `things`")
+self.assertEqual(query.args, [])
+
+query = INSERT("people").VALUES(stuff=1, things=2).VALUES(3, 4)
+query.SELECT("stuff").FROM("things")
+
+self.assertRaisesRegex(relations_sql.SQLError, "set VALUES or SELECT but not both", query.generate)
+```
+
+# update
+
+```python
+query = UPDATE("people").SET(stuff="things").WHERE(things="stuff")
+query.OPTIONS("FAST").ORDER_BY("yin", yang=DESC).LIMIT(5)
+
+query.generate()
+self.assertEqual(query.sql, "UPDATE FAST `people` SET `stuff`=%s WHERE `things`=%s ORDER BY `yin`,`yang` DESC LIMIT %s")
+self.assertEqual(query.args, ["things", "stuff", 5])
+
+query.LIMIT(10)
+
+self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", query.generate)
+```
+
+# delete
+
+```python
+query = DELETE("people").WHERE(things="stuff")
+query.OPTIONS("FAST").ORDER_BY("yin", yang=DESC).LIMIT(5)
+
+query.generate()
+self.assertEqual(query.sql, "DELETE FAST FROM `people` WHERE `things`=%s ORDER BY `yin`,`yang` DESC LIMIT %s")
+self.assertEqual(query.args, ["stuff", 5])
+
+query.LIMIT(10)
+
+self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", query.generate)
+```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Module for interacting with Relations and SQL
 
-This is an abstract library that'll be used to create libraries for pymysql, psycopg2, sqlite3, etc.
+This is an abstract library that'll be used to inject into the source libraries for pymysql, psycopg2, sqlite3, etc.
 
-But here's some of the main unittests so you get the general idea.
+But folks may find it useful for their usages. So here's some of the main unittests so you get the general idea.
 
 # import
 
@@ -113,3 +113,77 @@ query.LIMIT(10)
 
 self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", query.generate)
 ```
+
+# inherit
+
+The unittest demonstrate how to abstract through inheritance. Classes know which other classes they'll need through class attributes.
+
+The unittests are where the backticks escaping comes from. It's not a default or anything.
+
+In `test_clause.py`
+
+```python
+class OPTIONS(relations_sql.OPTIONS):
+
+    pass
+
+
+class FIELDS(relations_sql.FIELDS):
+
+    ARGS = test_expression.FIELD
+    KWARG = test_expression.FIELD
+    KWARGS = test_expression.AS
+```
+
+In `test_query.py`
+
+```python
+class SELECT(relations_sql.SELECT):
+
+    CLAUSES = collections.OrderedDict([
+        ("OPTIONS", test_clause.OPTIONS),
+        ("FIELDS", test_clause.FIELDS),
+        ("FROM", test_clause.FROM),
+        ("WHERE", test_clause.WHERE),
+        ("GROUP_BY", test_clause.GROUP_BY),
+        ("HAVING", test_clause.HAVING),
+        ("ORDER_BY", test_clause.ORDER_BY),
+        ("LIMIT", test_clause.LIMIT)
+    ])
+
+
+class INSERT(relations_sql.INSERT):
+
+    CLAUSES = collections.OrderedDict([
+        ("OPTIONS", test_clause.OPTIONS),
+        ("TABLE", test_expression.TABLE),
+        ("FIELDS", test_expression.NAMES),
+        ("VALUES", test_clause.VALUES),
+        ("SELECT", SELECT)
+    ])
+
+
+class UPDATE(relations_sql.UPDATE):
+
+    CLAUSES = collections.OrderedDict([
+        ("OPTIONS", test_clause.OPTIONS),
+        ("TABLE", test_expression.TABLE),
+        ("SET", test_clause.SET),
+        ("WHERE", test_clause.WHERE),
+        ("ORDER_BY", test_clause.ORDER_BY),
+        ("LIMIT", test_clause.LIMIT)
+    ])
+
+
+class DELETE(relations_sql.DELETE):
+
+    CLAUSES = collections.OrderedDict([
+        ("OPTIONS", test_clause.OPTIONS),
+        ("TABLE", test_expression.TABLE),
+        ("WHERE", test_clause.WHERE),
+        ("ORDER_BY", test_clause.ORDER_BY),
+        ("LIMIT", test_clause.LIMIT)
+    ])
+```
+
+In the case of query classes, the OrderedDict's there also specific the order in which clauses are generated and appended. So it's pretty easy to extend.

--- a/lib/relations_sql/__init__.py
+++ b/lib/relations_sql/__init__.py
@@ -7,4 +7,4 @@ from relations_sql.expression import *
 from relations_sql.criterion import *
 from relations_sql.criteria import *
 from relations_sql.clause import *
-from relations_sql.statement import *
+from relations_sql.query import *

--- a/lib/relations_sql/query.py
+++ b/lib/relations_sql/query.py
@@ -132,7 +132,7 @@ class SELECT(QUERY):
 
 class INSERT(QUERY):
     """
-    INSERT statement
+    INSERT query
     """
 
     NAME = "INSERT"
@@ -228,7 +228,7 @@ class LIMITED(QUERY):
 
 class UPDATE(LIMITED):
     """
-    UPDATE statement
+    UPDATE query
     """
 
     NAME = "UPDATE"
@@ -245,7 +245,7 @@ class UPDATE(LIMITED):
 
 class DELETE(LIMITED):
     """
-    DELETE statement
+    DELETE query
     """
 
     NAME = "DELETE"

--- a/lib/relations_sql/query.py
+++ b/lib/relations_sql/query.py
@@ -6,7 +6,7 @@ import collections
 
 import relations_sql
 
-class STATEMENT(relations_sql.EXPRESSION):
+class QUERY(relations_sql.EXPRESSION):
     """
     Base query
     """
@@ -98,7 +98,7 @@ class STATEMENT(relations_sql.EXPRESSION):
         self.sql = f"{self.NAME} {' '.join(sql)}"
 
 
-class SELECT(STATEMENT):
+class SELECT(QUERY):
     """
     SELECT
     """
@@ -130,7 +130,7 @@ class SELECT(STATEMENT):
         return self.FIELDS(*args, **kwargs)
 
 
-class INSERT(STATEMENT):
+class INSERT(QUERY):
     """
     INSERT statement
     """
@@ -194,7 +194,7 @@ class INSERT(STATEMENT):
         self.sql = f"{self.NAME} {' '.join(sql)}"
 
 
-class LIMITED(STATEMENT):
+class LIMITED(QUERY):
     """
     Clause that has a limit
     """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 setup(
     name="relations-sql",
-    version="0.1.0",
+    version="0.2.0",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations_sql',
@@ -12,7 +12,7 @@ setup(
         'relations_sql.criterion',
         'relations_sql.criteria',
         'relations_sql.clause',
-        'relations_sql.statement'
+        'relations_sql.query'
     ],
     install_requires=[]
 )

--- a/test/test_relations_sql/test_query.py
+++ b/test/test_relations_sql/test_query.py
@@ -25,63 +25,63 @@ class TestQUERY(unittest.TestCase):
 
     def test___init__(self):
 
-        statement = QUERY()
+        query = QUERY()
 
-        self.assertEqual(statement.SELECT.expressions, [])
-        self.assertEqual(statement.FROM.expressions, [])
+        self.assertEqual(query.SELECT.expressions, [])
+        self.assertEqual(query.FROM.expressions, [])
 
-        statement = QUERY(SELECT="people.stuff", FROM=test_clause.FROM("things"))
+        query = QUERY(SELECT="people.stuff", FROM=test_clause.FROM("things"))
 
-        self.assertEqual(statement.SELECT.expressions[0].table.name, "people")
-        self.assertEqual(statement.SELECT.expressions[0].name, "stuff")
-        self.assertEqual(statement.FROM.expressions[0].name, "things")
+        self.assertEqual(query.SELECT.expressions[0].table.name, "people")
+        self.assertEqual(query.SELECT.expressions[0].name, "stuff")
+        self.assertEqual(query.FROM.expressions[0].name, "things")
 
         self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for QUERY", QUERY, nope=False)
 
     def test___getattr__(self):
 
         model = unittest.mock.MagicMock()
-        statement = QUERY(SELECT="people.stuff", FROM="things").bind(model)
+        query = QUERY(SELECT="people.stuff", FROM="things").bind(model)
 
-        statement.retrieve(False)
+        query.retrieve(False)
 
         model.retrieve.assert_called_once_with(False)
 
         def nope():
 
-            statement.nope
+            query.nope
 
         self.assertRaisesRegex(AttributeError, "object has no attribute", nope)
 
     def test___len__(self):
 
-        statement = QUERY(SELECT="people.stuff", FROM="things")
+        query = QUERY(SELECT="people.stuff", FROM="things")
 
-        self.assertEqual(len(statement), 2)
+        self.assertEqual(len(query), 2)
 
     def test_check(self):
 
-        statement = QUERY(SELECT="people.stuff", FROM="things")
+        query = QUERY(SELECT="people.stuff", FROM="things")
 
-        statement.check({})
-        self.assertEqual(statement.clauses, {})
+        query.check({})
+        self.assertEqual(query.clauses, {})
 
         self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for QUERY", QUERY, nope=False)
 
     def test_bind(self):
 
         model = unittest.mock.MagicMock()
-        statement = QUERY(SELECT="people.stuff", FROM="things").bind(model)
+        query = QUERY(SELECT="people.stuff", FROM="things").bind(model)
 
-        self.assertEqual(statement.model, model)
+        self.assertEqual(query.model, model)
 
     def test_generate(self):
 
-        statement = QUERY(SELECT="people.stuff", FROM="things")
+        query = QUERY(SELECT="people.stuff", FROM="things")
 
-        statement.generate()
-        self.assertEqual(statement.sql, "QUERY `people`.`stuff` FROM `things`")
-        self.assertEqual(statement.args, [])
+        query.generate()
+        self.assertEqual(query.sql, "QUERY `people`.`stuff` FROM `things`")
+        self.assertEqual(query.args, [])
 
 
 ASC = test_expression.ASC
@@ -106,23 +106,23 @@ class TestSELECT(unittest.TestCase):
 
     def test___init__(self):
 
-        statement = SELECT("*").FROM("people").WHERE(stuff__gt="things")
+        query = SELECT("*").FROM("people").WHERE(stuff__gt="things")
 
-        self.assertEqual(statement.FIELDS.expressions[0].name, "*")
-        self.assertEqual(statement.FROM.expressions[0].name, "people")
-        self.assertIsInstance(statement.WHERE.expressions[0], test_criterion.GT)
-        self.assertEqual(statement.WHERE.expressions[0].left.name, "stuff")
-        self.assertEqual(statement.WHERE.expressions[0].right.value, "things")
+        self.assertEqual(query.FIELDS.expressions[0].name, "*")
+        self.assertEqual(query.FROM.expressions[0].name, "people")
+        self.assertIsInstance(query.WHERE.expressions[0], test_criterion.GT)
+        self.assertEqual(query.WHERE.expressions[0].left.name, "stuff")
+        self.assertEqual(query.WHERE.expressions[0].right.value, "things")
 
     def test_generate(self):
 
-        statement = SELECT("*").OPTIONS("FAST").FROM("people").WHERE(stuff__gt="things")
+        query = SELECT("*").OPTIONS("FAST").FROM("people").WHERE(stuff__gt="things")
 
-        statement.generate()
-        self.assertEqual(statement.sql, "SELECT FAST * FROM `people` WHERE `stuff`>%s")
-        self.assertEqual(statement.args, ["things"])
+        query.generate()
+        self.assertEqual(query.sql, "SELECT FAST * FROM `people` WHERE `stuff`>%s")
+        self.assertEqual(query.args, ["things"])
 
-        statement = SELECT(
+        query = SELECT(
             "*"
         ).FROM(
             people=SELECT(
@@ -140,25 +140,25 @@ class TestSELECT(unittest.TestCase):
             )
         )
 
-        statement.generate()
-        self.assertEqual(statement.sql,
+        query.generate()
+        self.assertEqual(query.sql,
             "SELECT * FROM (SELECT `a`.`b`.`c` FROM `d`.`e`) "
             "AS `people` WHERE `stuff` IN "
             "(SELECT `f` FROM `g` WHERE `things`>%s>JSON(%s))"
         )
-        self.assertEqual(statement.args, ['$."a"[0][-1]."2"."-3"', '5'])
+        self.assertEqual(query.args, ['$."a"[0][-1]."2"."-3"', '5'])
 
-        statement.GROUP_BY("fee", "fie").HAVING(foe="fum").ORDER_BY("yin", yang=DESC).LIMIT(1, 2)
+        query.GROUP_BY("fee", "fie").HAVING(foe="fum").ORDER_BY("yin", yang=DESC).LIMIT(1, 2)
 
-        statement.generate()
-        self.assertEqual(statement.sql,
+        query.generate()
+        self.assertEqual(query.sql,
             "SELECT * FROM (SELECT `a`.`b`.`c` FROM `d`.`e`) "
             "AS `people` WHERE `stuff` IN "
             "(SELECT `f` FROM `g` WHERE `things`>%s>JSON(%s)) "
             "GROUP BY `fee`,`fie` HAVING `foe`=%s "
             "ORDER BY `yin`,`yang` DESC LIMIT %s,%s"
         )
-        self.assertEqual(statement.args, ['$."a"[0][-1]."2"."-3"', '5', 'fum', 1, 2])
+        self.assertEqual(query.args, ['$."a"[0][-1]."2"."-3"', '5', 'fum', 1, 2])
 
 
 class INSERT(relations_sql.INSERT):
@@ -177,50 +177,50 @@ class TestINSERT(unittest.TestCase):
 
     def test___init__(self):
 
-        statement = INSERT("people.stuff", "things", SELECT="*")
+        query = INSERT("people.stuff", "things", SELECT="*")
 
-        self.assertEqual(statement.TABLE.name, "stuff")
-        self.assertEqual(statement.TABLE.schema.name, "people")
-        self.assertEqual(statement.FIELDS.expressions[0].name, "things")
-        self.assertEqual(statement.SELECT.FIELDS.expressions[0].name, "*")
+        self.assertEqual(query.TABLE.name, "stuff")
+        self.assertEqual(query.TABLE.schema.name, "people")
+        self.assertEqual(query.FIELDS.expressions[0].name, "things")
+        self.assertEqual(query.SELECT.FIELDS.expressions[0].name, "*")
 
-        statement = INSERT("people.stuff", FIELDS=["things"], SELECT=SELECT("stuff").FROM("things"))
+        query = INSERT("people.stuff", FIELDS=["things"], SELECT=SELECT("stuff").FROM("things"))
 
-        self.assertEqual(statement.TABLE.name, "stuff")
-        self.assertEqual(statement.TABLE.schema.name, "people")
-        self.assertEqual(statement.FIELDS.expressions[0].name, "things")
+        self.assertEqual(query.TABLE.name, "stuff")
+        self.assertEqual(query.TABLE.schema.name, "people")
+        self.assertEqual(query.FIELDS.expressions[0].name, "things")
 
         self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for INSERT", INSERT, "table", nope=False)
 
     def test_field(self):
 
-        statement = INSERT("people.stuff")
+        query = INSERT("people.stuff")
 
-        statement.field(["things"])
-        self.assertEqual(statement.FIELDS.expressions[0].name, "things")
+        query.field(["things"])
+        self.assertEqual(query.FIELDS.expressions[0].name, "things")
 
-        statement.field(["thingies"])
-        self.assertEqual(statement.FIELDS.expressions[0].name, "things")
+        query.field(["thingies"])
+        self.assertEqual(query.FIELDS.expressions[0].name, "things")
 
     def test_generate(self):
 
-        statement = INSERT("people").VALUES(stuff=1, things=2).VALUES(3, 4)
+        query = INSERT("people").VALUES(stuff=1, things=2).VALUES(3, 4)
 
-        statement.generate()
-        self.assertEqual(statement.sql,"INSERT INTO `people` (`stuff`,`things`) VALUES (%s,%s),(%s,%s)")
-        self.assertEqual(statement.args, [1, 2, 3, 4])
+        query.generate()
+        self.assertEqual(query.sql,"INSERT INTO `people` (`stuff`,`things`) VALUES (%s,%s),(%s,%s)")
+        self.assertEqual(query.args, [1, 2, 3, 4])
 
-        statement = INSERT("people").OPTIONS("FAST")
-        statement.SELECT("stuff").FROM("things")
+        query = INSERT("people").OPTIONS("FAST")
+        query.SELECT("stuff").FROM("things")
 
-        statement.generate()
-        self.assertEqual(statement.sql,"INSERT FAST INTO `people` SELECT `stuff` FROM `things`")
-        self.assertEqual(statement.args, [])
+        query.generate()
+        self.assertEqual(query.sql,"INSERT FAST INTO `people` SELECT `stuff` FROM `things`")
+        self.assertEqual(query.args, [])
 
-        statement = INSERT("people").VALUES(stuff=1, things=2).VALUES(3, 4)
-        statement.SELECT("stuff").FROM("things")
+        query = INSERT("people").VALUES(stuff=1, things=2).VALUES(3, 4)
+        query.SELECT("stuff").FROM("things")
 
-        self.assertRaisesRegex(relations_sql.SQLError, "set VALUES or SELECT but not both", statement.generate)
+        self.assertRaisesRegex(relations_sql.SQLError, "set VALUES or SELECT but not both", query.generate)
 
 
 class LIMITED(relations_sql.LIMITED):
@@ -239,34 +239,34 @@ class TestLIMITED(unittest.TestCase):
 
     def test___init__(self):
 
-        statement = LIMITED("people", SELECT="*")
+        query = LIMITED("people", SELECT="*")
 
-        self.assertEqual(statement.SELECT.expressions[0].name, "*")
-        self.assertEqual(statement.TABLE.name, "people")
+        self.assertEqual(query.SELECT.expressions[0].name, "*")
+        self.assertEqual(query.TABLE.name, "people")
 
-        statement = LIMITED("people", SELECT=test_clause.FIELDS("*"))
+        query = LIMITED("people", SELECT=test_clause.FIELDS("*"))
 
-        self.assertEqual(statement.SELECT.expressions[0].name, "*")
-        self.assertEqual(statement.TABLE.name, "people")
+        self.assertEqual(query.SELECT.expressions[0].name, "*")
+        self.assertEqual(query.TABLE.name, "people")
 
-        statement = LIMITED("people")
+        query = LIMITED("people")
 
-        self.assertEqual(statement.SELECT.expressions, [])
-        self.assertEqual(statement.TABLE.name, "people")
+        self.assertEqual(query.SELECT.expressions, [])
+        self.assertEqual(query.TABLE.name, "people")
 
         self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for INSERT", INSERT, "table", nope=False)
 
     def test_generate(self):
 
-        statement = LIMITED("people", SELECT=test_clause.FIELDS("*"), LIMIT=5)
+        query = LIMITED("people", SELECT=test_clause.FIELDS("*"), LIMIT=5)
 
-        statement.generate()
-        self.assertEqual(statement.sql, "LIMITED `people` * LIMIT %s")
-        self.assertEqual(statement.args, [5])
+        query.generate()
+        self.assertEqual(query.sql, "LIMITED `people` * LIMIT %s")
+        self.assertEqual(query.args, [5])
 
-        statement.LIMIT(10)
+        query.LIMIT(10)
 
-        self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", statement.generate)
+        self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", query.generate)
 
 
 class UPDATE(relations_sql.UPDATE):
@@ -288,16 +288,16 @@ class TestUPDATE(unittest.TestCase):
 
     def test_generate(self):
 
-        statement = UPDATE("people").SET(stuff="things").WHERE(things="stuff")
-        statement.OPTIONS("FAST").ORDER_BY("yin", yang=DESC).LIMIT(5)
+        query = UPDATE("people").SET(stuff="things").WHERE(things="stuff")
+        query.OPTIONS("FAST").ORDER_BY("yin", yang=DESC).LIMIT(5)
 
-        statement.generate()
-        self.assertEqual(statement.sql, "UPDATE FAST `people` SET `stuff`=%s WHERE `things`=%s ORDER BY `yin`,`yang` DESC LIMIT %s")
-        self.assertEqual(statement.args, ["things", "stuff", 5])
+        query.generate()
+        self.assertEqual(query.sql, "UPDATE FAST `people` SET `stuff`=%s WHERE `things`=%s ORDER BY `yin`,`yang` DESC LIMIT %s")
+        self.assertEqual(query.args, ["things", "stuff", 5])
 
-        statement.LIMIT(10)
+        query.LIMIT(10)
 
-        self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", statement.generate)
+        self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", query.generate)
 
 
 class DELETE(relations_sql.DELETE):
@@ -318,13 +318,13 @@ class TestDELETE(unittest.TestCase):
 
     def test_generate(self):
 
-        statement = DELETE("people").WHERE(things="stuff")
-        statement.OPTIONS("FAST").ORDER_BY("yin", yang=DESC).LIMIT(5)
+        query = DELETE("people").WHERE(things="stuff")
+        query.OPTIONS("FAST").ORDER_BY("yin", yang=DESC).LIMIT(5)
 
-        statement.generate()
-        self.assertEqual(statement.sql, "DELETE FAST FROM `people` WHERE `things`=%s ORDER BY `yin`,`yang` DESC LIMIT %s")
-        self.assertEqual(statement.args, ["stuff", 5])
+        query.generate()
+        self.assertEqual(query.sql, "DELETE FAST FROM `people` WHERE `things`=%s ORDER BY `yin`,`yang` DESC LIMIT %s")
+        self.assertEqual(query.args, ["stuff", 5])
 
-        statement.LIMIT(10)
+        query.LIMIT(10)
 
-        self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", statement.generate)
+        self.assertRaisesRegex(relations_sql.SQLError, "LIMIT can only be total", query.generate)

--- a/test/test_relations_sql/test_query.py
+++ b/test/test_relations_sql/test_query.py
@@ -271,8 +271,6 @@ class TestLIMITED(unittest.TestCase):
 
 class UPDATE(relations_sql.UPDATE):
 
-    NAME = "UPDATE"
-
     CLAUSES = collections.OrderedDict([
         ("OPTIONS", test_clause.OPTIONS),
         ("TABLE", test_expression.TABLE),
@@ -301,8 +299,6 @@ class TestUPDATE(unittest.TestCase):
 
 
 class DELETE(relations_sql.DELETE):
-
-    NAME = "DELETE"
 
     CLAUSES = collections.OrderedDict([
         ("OPTIONS", test_clause.OPTIONS),

--- a/test/test_relations_sql/test_query.py
+++ b/test/test_relations_sql/test_query.py
@@ -10,38 +10,38 @@ import collections
 import relations_sql
 
 
-class STATEMENT(relations_sql.STATEMENT):
+class QUERY(relations_sql.QUERY):
 
-    NAME = "STATEMENT"
+    NAME = "QUERY"
 
     CLAUSES = collections.OrderedDict([
         ("SELECT", test_clause.FIELDS),
         ("FROM", test_clause.FROM)
     ])
 
-class TestSTATEMENT(unittest.TestCase):
+class TestQUERY(unittest.TestCase):
 
     maxDiff = None
 
     def test___init__(self):
 
-        statement = STATEMENT()
+        statement = QUERY()
 
         self.assertEqual(statement.SELECT.expressions, [])
         self.assertEqual(statement.FROM.expressions, [])
 
-        statement = STATEMENT(SELECT="people.stuff", FROM=test_clause.FROM("things"))
+        statement = QUERY(SELECT="people.stuff", FROM=test_clause.FROM("things"))
 
         self.assertEqual(statement.SELECT.expressions[0].table.name, "people")
         self.assertEqual(statement.SELECT.expressions[0].name, "stuff")
         self.assertEqual(statement.FROM.expressions[0].name, "things")
 
-        self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for STATEMENT", STATEMENT, nope=False)
+        self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for QUERY", QUERY, nope=False)
 
     def test___getattr__(self):
 
         model = unittest.mock.MagicMock()
-        statement = STATEMENT(SELECT="people.stuff", FROM="things").bind(model)
+        statement = QUERY(SELECT="people.stuff", FROM="things").bind(model)
 
         statement.retrieve(False)
 
@@ -55,32 +55,32 @@ class TestSTATEMENT(unittest.TestCase):
 
     def test___len__(self):
 
-        statement = STATEMENT(SELECT="people.stuff", FROM="things")
+        statement = QUERY(SELECT="people.stuff", FROM="things")
 
         self.assertEqual(len(statement), 2)
 
     def test_check(self):
 
-        statement = STATEMENT(SELECT="people.stuff", FROM="things")
+        statement = QUERY(SELECT="people.stuff", FROM="things")
 
         statement.check({})
         self.assertEqual(statement.clauses, {})
 
-        self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for STATEMENT", STATEMENT, nope=False)
+        self.assertRaisesRegex(TypeError, "'nope' is an invalid keyword argument for QUERY", QUERY, nope=False)
 
     def test_bind(self):
 
         model = unittest.mock.MagicMock()
-        statement = STATEMENT(SELECT="people.stuff", FROM="things").bind(model)
+        statement = QUERY(SELECT="people.stuff", FROM="things").bind(model)
 
         self.assertEqual(statement.model, model)
 
     def test_generate(self):
 
-        statement = STATEMENT(SELECT="people.stuff", FROM="things")
+        statement = QUERY(SELECT="people.stuff", FROM="things")
 
         statement.generate()
-        self.assertEqual(statement.sql, "STATEMENT `people`.`stuff` FROM `things`")
+        self.assertEqual(statement.sql, "QUERY `people`.`stuff` FROM `things`")
         self.assertEqual(statement.args, [])
 
 


### PR DESCRIPTION
For models, a query might not be a statement, since the backend might not be a database. So let's call the main part query so everything lines up.