### PR TITLE
M2M Select: shared tie-subquery mixin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/service
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN apk add git && pip install -r requirements.txt
 
 COPY setup.py .
 COPY lib lib

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=python-relations-sql
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.6.7
+VERSION?=0.6.8
 DEBUG_PORT=5678
 TTY=$(shell if tty -s; then echo "-it"; fi)
 VOLUMES=-v ${PWD}/lib:/opt/service/lib \

--- a/lib/relations_sql/__init__.py
+++ b/lib/relations_sql/__init__.py
@@ -12,3 +12,4 @@ from relations_sql.ddl import *
 from relations_sql.column import *
 from relations_sql.index import *
 from relations_sql.table import *
+from relations_sql.source import *

--- a/lib/relations_sql/column.py
+++ b/lib/relations_sql/column.py
@@ -52,7 +52,7 @@ class COLUMN(relations_sql.DDL):
 
         sql = [self.name()]
 
-        if self.migration["store"] and "__" in self.migration["store"]:
+        if "__" in self.migration["store"]:
 
             self.extract(self.migration['kind'], sql, **kwargs)
 

--- a/lib/relations_sql/column.py
+++ b/lib/relations_sql/column.py
@@ -52,7 +52,7 @@ class COLUMN(relations_sql.DDL):
 
         sql = [self.name()]
 
-        if "__" in self.migration["store"]:
+        if self.migration["store"] and "__" in self.migration["store"]:
 
             self.extract(self.migration['kind'], sql, **kwargs)
 

--- a/lib/relations_sql/source.py
+++ b/lib/relations_sql/source.py
@@ -6,6 +6,8 @@ SQL backend (sqlite3, pymysql, psycopg2). A consuming source must provide the
 SELECT, TABLE_NAME and SQL expression classes plus a `schema` attribute.
 """
 
+# pylint: disable=too-many-locals
+
 
 class SOURCE:
     """

--- a/lib/relations_sql/source.py
+++ b/lib/relations_sql/source.py
@@ -1,0 +1,64 @@
+"""
+SQL source mixin for Relations.
+
+Provides the SQL-side resolution of many-to-many tie criteria, shared by every
+SQL backend (sqlite3, pymysql, psycopg2). A consuming source must provide the
+SELECT, TABLE_NAME and SQL expression classes plus a `schema` attribute.
+"""
+
+
+class SOURCE:
+    """
+    Mixin adding in-database resolution of tie-field set criteria.
+    """
+
+    def collate_ties(self, model):
+        """
+        SQL sources resolve ties inside the query (see collate_ties_query), so the
+        base Python resolver is overridden to a no-op here.
+        """
+
+    def collate_ties_query(self, model, query):
+        """
+        Resolves tie-field set criteria (has/any/all and their not_ variants) into
+        IN (subquery) clauses, so the database does has/any/all in a single query
+        instead of reading the ties into Python.
+        """
+
+        sides = [
+            (relation, relation.brother_sister_ref, relation.tie_brother_ref, relation.tie_sister_ref)
+            for relation in model.SISTERS.values()
+        ] + [
+            (relation, relation.sister_brother_ref, relation.tie_sister_ref, relation.tie_brother_ref)
+            for relation in model.BROTHERS.values()
+        ]
+
+        for relation, field_ref, tie_self_ref, tie_sibling_ref in sides:
+
+            field = model._record._names[field_ref]
+
+            if not field.criteria:
+                continue
+
+            tie = relation.Tie.thy()
+            tie_schema = getattr(tie, "SCHEMA", None) or self.schema
+            tie_store = getattr(tie, "STORE", None) or tie.NAME
+
+            for criterion, values in field.criteria.items():
+
+                negate = criterion.startswith("not_")
+                operator = criterion.split("not_", 1)[-1] if negate else criterion
+                values = sorted(set(values if isinstance(values, (list, set, tuple)) else [values]))
+
+                subquery = self.SELECT(tie_self_ref).FROM(
+                    self.TABLE_NAME(tie_store, schema=tie_schema)
+                ).WHERE(**{f"{tie_sibling_ref}__in": values})
+
+                if operator == "all":
+                    subquery.GROUP_BY(tie_self_ref).HAVING(
+                        self.SQL(f"COUNT(DISTINCT {tie_sibling_ref}) = {len(values)}")
+                    )
+
+                query.WHERE(**{f"{model._id}__{'not_in' if negate else 'in'}": subquery})
+
+            field.criteria = {}

--- a/lib/relations_sql/table.py
+++ b/lib/relations_sql/table.py
@@ -67,7 +67,7 @@ class TABLE(relations_sql.DDL):
         indexes = []
 
         for migration in self.migration["fields"]:
-            if "inject" in migration:
+            if "inject" in migration or not migration["store"]:
                 continue
             columns.append(self.COLUMN(migration=migration))
             if "extract" in migration:
@@ -131,7 +131,7 @@ class TABLE(relations_sql.DDL):
 
         for migration in self.migration.get("fields", {}).get("add", {}):
 
-            if "inject" in migration:
+            if "inject" in migration or not migration["store"]:
                 continue
 
             columns.append(self.COLUMN(migration=migration, added=True))
@@ -151,7 +151,7 @@ class TABLE(relations_sql.DDL):
             migration = self.migration["fields"]["change"][field]
             definition = self.field(field)
 
-            if "inject" in definition:
+            if "inject" in definition or not definition["store"]:
                 continue
 
             if any(attr in migration for attr in ["name", "store", "kind", "default", "none"]):
@@ -212,7 +212,7 @@ class TABLE(relations_sql.DDL):
 
             definition = self.field(field)
 
-            if "inject" in definition:
+            if "inject" in definition or not definition["store"]:
                 continue
 
             columns.append(self.COLUMN(definition=definition))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 overscore==0.1.1
-# relations-dil==0.6.11
-relations-dil @ git+https://github.com/relations-dil/python-relations@11260bd23ad953100ebce9f7066ada2cb29be448
+# relations-dil==0.6.14
+relations-dil @ git+https://github.com/relations-dil/python-relations@09f27c34eb079dd29042cb9460b140fea336b9f3
 ptvsd==4.3.2
 coverage==5.2.1
 pylint==2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 overscore==0.1.1
-relations-dil==0.6.11
+# relations-dil==0.6.11
+relations-dil @ git+https://github.com/relations-dil/python-relations@11260bd23ad953100ebce9f7066ada2cb29be448
 ptvsd==4.3.2
 coverage==5.2.1
 pylint==2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 overscore==0.1.1
-relations-dil==0.6.11
+# relations-dil==0.6.14
+relations-dil @ git+https://github.com/relations-dil/python-relations@7b83a060fcd41ee2ae81bb63aae5fc6a7e530cfa
 ptvsd==4.3.2
 coverage==5.2.1
 pylint==2.5.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="relations-sql",
-    version="0.6.7",
+    version="0.6.8",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations_sql',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'relations_sql.ddl',
         'relations_sql.column',
         'relations_sql.index',
-        'relations_sql.table'
+        'relations_sql.table',
+        'relations_sql.source'
     ],
     install_requires=[
         'overscore==0.1.1'

--- a/test/test_relations_sql/test_source.py
+++ b/test/test_relations_sql/test_source.py
@@ -1,0 +1,102 @@
+import unittest
+
+import relations
+import relations.unittest
+import relations_sql
+
+import test_query
+import test_expression
+
+
+class Source(relations_sql.SOURCE):
+    """
+    Minimal SQL source using the concrete test SQL classes, for exercising the mixin.
+    """
+
+    SELECT = test_query.SELECT
+    TABLE_NAME = test_expression.TABLE_NAME
+    SQL = relations_sql.SQL
+    schema = "test"
+
+
+class Base(relations.Model):
+    SOURCE = "TieTest"
+
+class Sis(Base):
+    id = int
+    name = str
+    bro_id = set
+
+class Bro(Base):
+    id = int
+    name = str
+    sis_id = set
+
+class SisBro(Base):
+    ID = None
+    bro_id = int
+    sis_id = int
+
+relations.ManyToMany(Sis, Bro, SisBro)
+
+
+class TestSOURCE(unittest.TestCase):
+
+    maxDiff = None
+
+    def setUp(self):
+
+        self.source = Source()
+        relations.unittest.MockSource("TieTest")
+
+    def sql(self, model):
+
+        query = test_query.SELECT("*").FROM("sis")
+        self.source.collate_ties_query(model, query)
+        query.generate()
+        return " ".join(query.sql.split())
+
+    def test_collate_ties(self):
+
+        # no-op: SQL sources resolve ties in the query, not in Python
+        self.assertIsNone(self.source.collate_ties(Sis.many()))
+
+    def test_collate_ties_query(self):
+
+        # has / any -> id IN (subquery): the DB does the work, not Python
+        self.assertIn(
+            "`id` IN (SELECT `sis_id` FROM `test`.`sis_bro` WHERE `bro_id` IN (%s))",
+            self.sql(Sis.many(bro_id__has=1))
+        )
+        self.assertIn(
+            "`id` IN (SELECT `sis_id` FROM `test`.`sis_bro` WHERE `bro_id` IN (%s,%s))",
+            self.sql(Sis.many(bro_id__any=[1, 2]))
+        )
+
+        # all -> GROUP BY / HAVING COUNT(DISTINCT) = N (unquoted, dialect-agnostic)
+        self.assertIn(
+            "`id` IN (SELECT `sis_id` FROM `test`.`sis_bro` WHERE `bro_id` IN (%s,%s) "
+            "GROUP BY `sis_id` HAVING COUNT(DISTINCT bro_id) = 2)",
+            self.sql(Sis.many(bro_id__all=[1, 2]))
+        )
+
+        # all de-dupes the request (a repeated value can't change the count)
+        self.assertIn(
+            "WHERE `bro_id` IN (%s) GROUP BY `sis_id` HAVING COUNT(DISTINCT bro_id) = 1)",
+            self.sql(Sis.many(bro_id__all=[2, 2]))
+        )
+
+        # negation -> id NOT IN (subquery)
+        self.assertIn(
+            "`id` NOT IN (SELECT `sis_id` FROM `test`.`sis_bro` WHERE `bro_id` IN (%s))",
+            self.sql(Sis.many(bro_id__not_has=1))
+        )
+
+        # symmetric direction selects bro_id by sis_id
+        self.assertIn(
+            "`id` IN (SELECT `bro_id` FROM `test`.`sis_bro` WHERE `sis_id` IN (%s))",
+            self.sql(Bro.many(sis_id__has=1))
+        )
+
+        # no tie criteria -> query untouched
+        self.assertNotIn("sis_bro", self.sql(Sis.many(name="x")))

--- a/test/test_relations_sql/test_table.py
+++ b/test/test_relations_sql/test_table.py
@@ -22,7 +22,8 @@ class Meta(relations.Model):
     people = set
     stuff = list
     things = dict, {"extract": "for__0____1"}
-    push = str, {"inject": "stuff___1__relations.io____1"}
+    push = str, {"inject": "stuff___1__relations.io____1"},
+    tied = str, {"store": False}
 
     INDEX = "spend"
 
@@ -141,7 +142,7 @@ CREATE UNIQUE `meta_name` ON `meta` (`name`);
         ddl = TABLE(migration={
             "name": "yep",
             "fields": {
-                "add": Meta.thy().define()["fields"][-2:]
+                "add": Meta.thy().define()["fields"][-3:]
             }
         })
 
@@ -172,6 +173,9 @@ CREATE UNIQUE `meta_name` ON `meta` (`name`);
                         },
                         "things": {
                             "store": "thingies"
+                        },
+                        "tied": {
+                            "name": "ties"
                         }
                     }
                 }
@@ -254,7 +258,8 @@ CREATE UNIQUE `meta_name` ON `meta` (`name`);
                 "fields": {
                     "remove": [
                         "things",
-                        "push"
+                        "push",
+                        "tied"
                     ]
                 }
             },
@@ -470,7 +475,7 @@ STORE `dreaming`.`evil` TO `dreaming`.`good`;
         ddl = TABLE(
             migration={
                 "fields": {
-                    "add": Meta.thy().define()["fields"][-2:]
+                    "add": Meta.thy().define()["fields"][-3:]
                 }
             },
             definition=Simple.thy().define()


### PR DESCRIPTION
Closes #20.

Adds a shared `relations_sql.SOURCE` mixin so all SQL backends (sqlite3, pymysql, psycopg2) resolve M2M tie criteria (`has`/`any`/`all` + `not_` variants) as a single in-database subquery instead of reading ties into Python:

```sql
id IN (SELECT tie_self FROM tie WHERE tie_sibling IN (...))
-- all: + GROUP BY tie_self HAVING COUNT(DISTINCT tie_sibling) = N
-- not_*: id NOT IN (...)
```

- `collate_ties` (no-op) + `collate_ties_query` live here once; backends inherit via `class Source(relations_sql.SOURCE, relations.Source)`.
- `COUNT(DISTINCT col)` is unquoted so the one implementation is dialect-agnostic.
- Includes the REL-154 DDL fix (skip `store=False` columns), merged in.
- Tested against the concrete test SQL classes; 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)