### PR TITLE
M2M attr: sibling-attribute filtering (SQL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=python-relations-sql
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.6.8
+VERSION?=0.6.9
 DEBUG_PORT=5678
 TTY=$(shell if tty -s; then echo "-it"; fi)
 VOLUMES=-v ${PWD}/lib:/opt/service/lib \

--- a/lib/relations_sql/source.py
+++ b/lib/relations_sql/source.py
@@ -69,24 +69,23 @@ class SOURCE:
 
     def collate_attr_query(self, model, query):
         """
-        Resolves sibling-attribute criteria (bro__name=..., captured on model._ties).
-
-        A positive, non-aggregate filter (bro__name="Tom", bro__name__like, bro__name__in) is a
-        flat join: the tie table and the sibling table are added to the outer query's FROM and the
-        model->tie + tie->sibling joins plus the sibling predicate to its WHERE. Because a model
-        tied to several matching siblings would repeat, the model is marked _distinct (count and
-        retrieve honor it with COUNT(DISTINCT id) / SELECT DISTINCT).
-
-        all (every distinct value) and negation (NOT tied to a match) cannot be a flat predicate,
-        so they stay an id IN / NOT IN subquery, which keeps the outer query one row per model.
+        Resolves sibling-attribute criteria (bro__name=..., grouped per relation on model._ties)
+        into a flat join: the tie table and the sibling table are added to the outer query's FROM
+        and the model->tie + tie->sibling joins plus the sibling criteria to its WHERE. Every
+        sibling field operator (name, name__like, name__in, name__gt, ...) lands in WHERE, and
+        criteria on the same relation filter the same tied sibling. Because a model tied to several
+        matching siblings would repeat, it is marked _distinct (count and retrieve honor it with
+        COUNT(DISTINCT id) / SELECT DISTINCT).
         """
 
         model_store = getattr(model, "STORE", None) or model.NAME
         model._distinct = False
 
-        for relation, side, field, operator, negate, value in getattr(model, "_ties", []):
+        for name, criteria in getattr(model, "_ties", {}).items():
 
-            if side == "sister":
+            relation = model.SISTERS[name] if name in model.SISTERS else model.BROTHERS[name]
+
+            if name in model.SISTERS:
                 tie_self_ref, tie_sibling_ref = relation.tie_brother_ref, relation.tie_sister_ref
                 sibling, sibling_id = relation.Sister.thy(), relation.sister_id
             else:
@@ -94,46 +93,18 @@ class SOURCE:
                 sibling, sibling_id = relation.Brother.thy(), relation.brother_id
 
             tie = relation.Tie.thy()
-            tie_schema = getattr(tie, "SCHEMA", None) or self.schema
             tie_store = getattr(tie, "STORE", None) or tie.NAME
-            sib_schema = getattr(sibling, "SCHEMA", None) or self.schema
             sib_store = getattr(sibling, "STORE", None) or sibling.NAME
 
-            values = sorted(set(value if isinstance(value, (list, set, tuple)) else [value]))
+            tie_table = self.TABLE_NAME(tie_store, schema=getattr(tie, "SCHEMA", None) or self.schema)
+            sib_table = self.TABLE_NAME(sib_store, schema=getattr(sibling, "SCHEMA", None) or self.schema)
 
-            tie_table = self.TABLE_NAME(tie_store, schema=tie_schema)
-            sib_table = self.TABLE_NAME(sib_store, schema=sib_schema)
-
-            # join the tie table to the sibling table on the tie's sibling-id column
+            # model -> tie -> sibling joins, then the sibling field criteria (same tied sibling)
+            model_join = self.OP(**{f"{model_store}.{model._id}": self.COLUMN_NAME(tie_self_ref, table=tie_store)})
             sibling_join = self.OP(**{f"{tie_store}.{tie_sibling_ref}": self.COLUMN_NAME(sibling_id, table=sib_store)})
+            matches = [self.OP(**{f"{sib_store}.{predicate}": value}) for predicate, value in criteria.items()]
 
-            # the sibling predicate, matching any of the requested values; a field with its own
-            # operator (name__like) is OR'd per value, a plain field is a single IN
-            if "__" in field:
-                match = self.OR(*[self.OP(**{f"{sib_store}.{field}": item}) for item in values])
-                attr = field.rsplit("__", 1)[0]
-            else:
-                match = self.OP(**{f"{sib_store}.{field}__in": values})
-                attr = field
+            query.FROM(tie_table, sib_table).WHERE(model_join, sibling_join, *matches)
+            model._distinct = True
 
-            if operator == "all" or negate:
-
-                # aggregate / anti-join: an id IN / NOT IN subquery keeps the outer query one row per model
-                self_ref = self.COLUMN_NAME(tie_self_ref, table=tie_store)
-                subquery = self.SELECT(self_ref).FROM(tie_table, sib_table).WHERE(sibling_join, match)
-
-                if operator == "all":
-                    subquery.GROUP_BY(self_ref).HAVING(
-                        self.SQL(f"COUNT(DISTINCT {sib_store}.{attr}) = {len(values)}")
-                    )
-
-                query.WHERE(**{f"{model._id}__{'not_in' if negate else 'in'}": subquery})
-
-            else:
-
-                # flat join: tie + sibling tables into FROM, joins + predicate into WHERE
-                model_join = self.OP(**{f"{model_store}.{model._id}": self.COLUMN_NAME(tie_self_ref, table=tie_store)})
-                query.FROM(tie_table, sib_table).WHERE(model_join, sibling_join, match)
-                model._distinct = True
-
-        model._ties = []
+        model._ties = {}

--- a/lib/relations_sql/source.py
+++ b/lib/relations_sql/source.py
@@ -64,3 +64,76 @@ class SOURCE:
                 query.WHERE(**{f"{model._id}__{'not_in' if negate else 'in'}": subquery})
 
             field.criteria = {}
+
+        self.collate_attr_query(model, query)
+
+    def collate_attr_query(self, model, query):
+        """
+        Resolves sibling-attribute criteria (bro__name=..., captured on model._ties).
+
+        A positive, non-aggregate filter (bro__name="Tom", bro__name__like, bro__name__in) is a
+        flat join: the tie table and the sibling table are added to the outer query's FROM and the
+        model->tie + tie->sibling joins plus the sibling predicate to its WHERE. Because a model
+        tied to several matching siblings would repeat, the model is marked _distinct (count and
+        retrieve honor it with COUNT(DISTINCT id) / SELECT DISTINCT).
+
+        all (every distinct value) and negation (NOT tied to a match) cannot be a flat predicate,
+        so they stay an id IN / NOT IN subquery, which keeps the outer query one row per model.
+        """
+
+        model_store = getattr(model, "STORE", None) or model.NAME
+        model._distinct = False
+
+        for relation, side, field, operator, negate, value in getattr(model, "_ties", []):
+
+            if side == "sister":
+                tie_self_ref, tie_sibling_ref = relation.tie_brother_ref, relation.tie_sister_ref
+                sibling, sibling_id = relation.Sister.thy(), relation.sister_id
+            else:
+                tie_self_ref, tie_sibling_ref = relation.tie_sister_ref, relation.tie_brother_ref
+                sibling, sibling_id = relation.Brother.thy(), relation.brother_id
+
+            tie = relation.Tie.thy()
+            tie_schema = getattr(tie, "SCHEMA", None) or self.schema
+            tie_store = getattr(tie, "STORE", None) or tie.NAME
+            sib_schema = getattr(sibling, "SCHEMA", None) or self.schema
+            sib_store = getattr(sibling, "STORE", None) or sibling.NAME
+
+            values = sorted(set(value if isinstance(value, (list, set, tuple)) else [value]))
+
+            tie_table = self.TABLE_NAME(tie_store, schema=tie_schema)
+            sib_table = self.TABLE_NAME(sib_store, schema=sib_schema)
+
+            # join the tie table to the sibling table on the tie's sibling-id column
+            sibling_join = self.OP(**{f"{tie_store}.{tie_sibling_ref}": self.COLUMN_NAME(sibling_id, table=sib_store)})
+
+            # the sibling predicate, matching any of the requested values; a field with its own
+            # operator (name__like) is OR'd per value, a plain field is a single IN
+            if "__" in field:
+                match = self.OR(*[self.OP(**{f"{sib_store}.{field}": item}) for item in values])
+                attr = field.rsplit("__", 1)[0]
+            else:
+                match = self.OP(**{f"{sib_store}.{field}__in": values})
+                attr = field
+
+            if operator == "all" or negate:
+
+                # aggregate / anti-join: an id IN / NOT IN subquery keeps the outer query one row per model
+                self_ref = self.COLUMN_NAME(tie_self_ref, table=tie_store)
+                subquery = self.SELECT(self_ref).FROM(tie_table, sib_table).WHERE(sibling_join, match)
+
+                if operator == "all":
+                    subquery.GROUP_BY(self_ref).HAVING(
+                        self.SQL(f"COUNT(DISTINCT {sib_store}.{attr}) = {len(values)}")
+                    )
+
+                query.WHERE(**{f"{model._id}__{'not_in' if negate else 'in'}": subquery})
+
+            else:
+
+                # flat join: tie + sibling tables into FROM, joins + predicate into WHERE
+                model_join = self.OP(**{f"{model_store}.{model._id}": self.COLUMN_NAME(tie_self_ref, table=tie_store)})
+                query.FROM(tie_table, sib_table).WHERE(model_join, sibling_join, match)
+                model._distinct = True
+
+        model._ties = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 overscore==0.1.1
-relations-dil @ git+https://github.com/relations-dil/python-relations@ba6751b277e84905762274c88c6dfa49990538c1
+relations-dil @ git+https://github.com/relations-dil/python-relations@aa309087789d4b7ed459676c4343f61bb95a4af5
 ptvsd==4.3.2
 coverage==5.2.1
 pylint==2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 overscore==0.1.1
-relations-dil==0.6.14
+relations-dil @ git+https://github.com/relations-dil/python-relations@ba6751b277e84905762274c88c6dfa49990538c1
 ptvsd==4.3.2
 coverage==5.2.1
 pylint==2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 overscore==0.1.1
-relations-dil @ git+https://github.com/relations-dil/python-relations@aa309087789d4b7ed459676c4343f61bb95a4af5
+relations-dil==0.6.15
 ptvsd==4.3.2
 coverage==5.2.1
 pylint==2.5.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="relations-sql",
-    version="0.6.8",
+    version="0.6.9",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations_sql',

--- a/test/test_relations_sql/test_source.py
+++ b/test/test_relations_sql/test_source.py
@@ -6,6 +6,7 @@ import relations_sql
 
 import test_query
 import test_expression
+import test_criteria
 
 
 class Source(relations_sql.SOURCE):
@@ -15,6 +16,9 @@ class Source(relations_sql.SOURCE):
 
     SELECT = test_query.SELECT
     TABLE_NAME = test_expression.TABLE_NAME
+    COLUMN_NAME = test_expression.COLUMN_NAME
+    OP = test_criteria.OP
+    OR = test_criteria.OR
     SQL = relations_sql.SQL
     schema = "test"
 
@@ -51,7 +55,7 @@ class TestSOURCE(unittest.TestCase):
 
     def sql(self, model):
 
-        query = test_query.SELECT("*").FROM("sis")
+        query = test_query.SELECT("*").FROM(getattr(model, "STORE", None) or model.NAME)
         self.source.collate_ties_query(model, query)
         query.generate()
         return " ".join(query.sql.split())
@@ -100,3 +104,60 @@ class TestSOURCE(unittest.TestCase):
 
         # no tie criteria -> query untouched
         self.assertNotIn("sis_bro", self.sql(Sis.many(name="x")))
+
+    def test_collate_attr_query(self):
+
+        # bro__name -> FLAT join: tie + sibling added to FROM, joins + criteria in WHERE, NO subquery
+        flat = self.sql(Sis.many(bro__name="Tom"))
+        self.assertIn(
+            "FROM `sis`,`test`.`sis_bro`,`test`.`bro` "
+            "WHERE `sis`.`id`=(`sis_bro`.`sis_id`) AND `sis_bro`.`bro_id`=(`bro`.`id`) AND `bro`.`name` IN (%s)",
+            flat
+        )
+        self.assertNotIn("(SELECT", flat)
+
+        # any -> IN over the requested values, still flat
+        self.assertIn(
+            "AND `bro`.`name` IN (%s,%s)",
+            self.sql(Sis.many(bro__name__any=["Tom", "Dick"]))
+        )
+
+        # a sibling field operator (like) is OR'd per value, still flat
+        self.assertIn(
+            "AND (`bro`.`name` LIKE %s OR `bro`.`name` LIKE %s)",
+            self.sql(Sis.many(bro__name__like__any=["ar", "om"]))
+        )
+
+        # all -> the exception: id IN subquery with GROUP BY / HAVING COUNT(DISTINCT attr)
+        self.assertIn(
+            "`id` IN (SELECT `sis_bro`.`sis_id` FROM `test`.`sis_bro`,`test`.`bro` "
+            "WHERE `sis_bro`.`bro_id`=(`bro`.`id`) AND `bro`.`name` IN (%s,%s) "
+            "GROUP BY `sis_bro`.`sis_id` HAVING COUNT(DISTINCT bro.name) = 2)",
+            self.sql(Sis.many(bro__name__all=["Tom", "Dick"]))
+        )
+
+        # negation -> the exception: id NOT IN subquery (a flat predicate would be wrong)
+        self.assertIn(
+            "`id` NOT IN (SELECT `sis_bro`.`sis_id` FROM `test`.`sis_bro`,`test`.`bro` "
+            "WHERE `sis_bro`.`bro_id`=(`bro`.`id`) AND `bro`.`name` IN (%s))",
+            self.sql(Sis.many(bro__name__not_has="Tom"))
+        )
+
+        # symmetric: brothers filtered by a tied sister's attribute (flat)
+        self.assertIn(
+            "FROM `bro`,`test`.`sis_bro`,`test`.`sis` "
+            "WHERE `bro`.`id`=(`sis_bro`.`bro_id`) AND `sis_bro`.`sis_id`=(`sis`.`id`) AND `sis`.`name` IN (%s)",
+            self.sql(Bro.many(sis__name="Sue"))
+        )
+
+        # a flat join marks the model for DISTINCT (count/retrieve dedupe); a subquery does not
+        joined = Sis.many(bro__name="Tom")
+        self.sql(joined)
+        self.assertTrue(getattr(joined, "_distinct", False))
+
+        aggregate = Sis.many(bro__name__all=["Tom", "Dick"])
+        self.sql(aggregate)
+        self.assertFalse(getattr(aggregate, "_distinct", False))
+
+        # no attr criteria -> query untouched
+        self.assertNotIn("`bro`.`name`", self.sql(Sis.many(bro_id__has=1)))

--- a/test/test_relations_sql/test_source.py
+++ b/test/test_relations_sql/test_source.py
@@ -111,53 +111,42 @@ class TestSOURCE(unittest.TestCase):
         flat = self.sql(Sis.many(bro__name="Tom"))
         self.assertIn(
             "FROM `sis`,`test`.`sis_bro`,`test`.`bro` "
-            "WHERE `sis`.`id`=(`sis_bro`.`sis_id`) AND `sis_bro`.`bro_id`=(`bro`.`id`) AND `bro`.`name` IN (%s)",
+            "WHERE `sis`.`id`=(`sis_bro`.`sis_id`) AND `sis_bro`.`bro_id`=(`bro`.`id`) AND `bro`.`name`=%s",
             flat
         )
         self.assertNotIn("(SELECT", flat)
 
-        # any -> IN over the requested values, still flat
+        # a field operator lands straight on the sibling: in (any of), like
         self.assertIn(
             "AND `bro`.`name` IN (%s,%s)",
-            self.sql(Sis.many(bro__name__any=["Tom", "Dick"]))
+            self.sql(Sis.many(bro__name__in=["Tom", "Dick"]))
         )
-
-        # a sibling field operator (like) is OR'd per value, still flat
         self.assertIn(
-            "AND (`bro`.`name` LIKE %s OR `bro`.`name` LIKE %s)",
-            self.sql(Sis.many(bro__name__like__any=["ar", "om"]))
+            "AND `bro`.`name` LIKE %s",
+            self.sql(Sis.many(bro__name__like="ar"))
         )
 
-        # all -> the exception: id IN subquery with GROUP BY / HAVING COUNT(DISTINCT attr)
+        # criteria on the same relation filter the same tied sibling (one join, AND'd)
         self.assertIn(
-            "`id` IN (SELECT `sis_bro`.`sis_id` FROM `test`.`sis_bro`,`test`.`bro` "
-            "WHERE `sis_bro`.`bro_id`=(`bro`.`id`) AND `bro`.`name` IN (%s,%s) "
-            "GROUP BY `sis_bro`.`sis_id` HAVING COUNT(DISTINCT bro.name) = 2)",
-            self.sql(Sis.many(bro__name__all=["Tom", "Dick"]))
+            "FROM `sis`,`test`.`sis_bro`,`test`.`bro` "
+            "WHERE `sis`.`id`=(`sis_bro`.`sis_id`) AND `sis_bro`.`bro_id`=(`bro`.`id`) "
+            "AND `bro`.`name`=%s AND `bro`.`id`>%s",
+            self.sql(Sis.many(bro__name="Tom", bro__id__gt=5))
         )
 
-        # negation -> the exception: id NOT IN subquery (a flat predicate would be wrong)
-        self.assertIn(
-            "`id` NOT IN (SELECT `sis_bro`.`sis_id` FROM `test`.`sis_bro`,`test`.`bro` "
-            "WHERE `sis_bro`.`bro_id`=(`bro`.`id`) AND `bro`.`name` IN (%s))",
-            self.sql(Sis.many(bro__name__not_has="Tom"))
-        )
-
-        # symmetric: brothers filtered by a tied sister's attribute (flat)
+        # symmetric: brothers filtered by a tied sister's attribute
         self.assertIn(
             "FROM `bro`,`test`.`sis_bro`,`test`.`sis` "
-            "WHERE `bro`.`id`=(`sis_bro`.`bro_id`) AND `sis_bro`.`sis_id`=(`sis`.`id`) AND `sis`.`name` IN (%s)",
+            "WHERE `bro`.`id`=(`sis_bro`.`bro_id`) AND `sis_bro`.`sis_id`=(`sis`.`id`) AND `sis`.`name`=%s",
             self.sql(Bro.many(sis__name="Sue"))
         )
 
-        # a flat join marks the model for DISTINCT (count/retrieve dedupe); a subquery does not
+        # a flat attr join marks the model for DISTINCT (count/retrieve dedupe)
         joined = Sis.many(bro__name="Tom")
         self.sql(joined)
         self.assertTrue(getattr(joined, "_distinct", False))
 
-        aggregate = Sis.many(bro__name__all=["Tom", "Dick"])
-        self.sql(aggregate)
-        self.assertFalse(getattr(aggregate, "_distinct", False))
-
-        # no attr criteria -> query untouched
-        self.assertNotIn("`bro`.`name`", self.sql(Sis.many(bro_id__has=1)))
+        # no attr criteria -> query untouched, not marked
+        plain = Sis.many(bro_id__has=1)
+        self.assertNotIn("`bro`.`name`", self.sql(plain))
+        self.assertFalse(getattr(plain, "_distinct", False))


### PR DESCRIPTION
## M2M attr — sibling-attribute filtering (SQL builder)

The SQL-side resolution of `Sis.many(bro__name="Tom")` for every SQL backend, building on core (relations-dil#69).

### Flat join — no subquery
`collate_attr_query` reads the per-relation sibling criteria from `model._ties` and adds a flat join: the tie table and the sibling table go into `FROM`, and the model↔tie + tie↔sibling joins plus the sibling field criteria go into `WHERE`:

```sql
SELECT * FROM sis, sis_bro, bro
WHERE sis.id = sis_bro.sis_id AND sis_bro.bro_id = bro.id AND bro.name = %s
```

Any field operator lands straight in WHERE (`bro.name IN (...)`, `LIKE`, …); criteria on one relation filter one tied sibling. No subquery, no aggregation. The model is marked `_distinct` so backends dedupe the rows the join multiplies. The tie-id Select path (`bro_id__has=…`) is unchanged.

### Tests
SQL-shape tests for the flat join (grouped criteria, symmetric direction, the `_distinct` marker) plus the existing tie-id Select tests. All gates green: build → test (167, 100%) → lint (10.00) → setup, against published `relations-dil 0.6.15`.

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
